### PR TITLE
add changes for testrun on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
-checkpoint/*
+checkpoint/
+*.jpg

--- a/src/models/skywork_unipic_dev.py
+++ b/src/models/skywork_unipic_dev.py
@@ -15,64 +15,7 @@ from einops import rearrange
 
 
 def _load_state_dict_with_ds(module_to_load, state_dict, start_prefix="", strict=True):
-    try:
-        import deepspeed
-    except ImportError:
-        raise ImportError("deepspeed is not installed. Please install deepspeed to use this feature.")
-    
-    # copy state_dict so _load_from_state_dict can modify it
-    metadata = getattr(state_dict, "_metadata", None)
-    state_dict = state_dict.copy()
-    if metadata is not None:
-        state_dict._metadata = metadata
-
-    error_msgs = []
-    missing_keys = []
-    unexpected_keys = []
-
-    def load(module: torch.nn.Module, state_dict, prefix=""):
-        local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
-        args = (state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
-        # Parameters of module and children will start with prefix. We can exit early if there are none in this
-        # state_dict
-        if len([key for key in state_dict if key.startswith(prefix)]) > 0:
-                # In sharded models, each shard has only part of the full state_dict, so only gather
-                # parameters that are in the current state_dict.
-                named_parameters = dict(
-                    module.named_parameters(prefix=prefix[:-1], recurse=False)
-                )
-                params_to_gather = [
-                    named_parameters[k]
-                    for k in state_dict.keys()
-                    if k in named_parameters
-                ]
-                if len(params_to_gather) > 0:
-                    # because zero3 puts placeholders in model params, this context
-                    # manager gathers (unpartitions) the params of the current layer, then loads from
-                    # the state dict and then re-partitions them again
-                    with deepspeed.zero.GatheredParameters(
-                        params_to_gather, modifier_rank=0
-                    ):
-                        if deepspeed.comm.get_rank() == 0:
-                            module._load_from_state_dict(*args)
-        else:
-            module._load_from_state_dict(*args)
-
-        for name, child in module._modules.items():
-            if child is not None:
-                load(child, state_dict, prefix + name + ".")
-
-    load(module_to_load, state_dict, start_prefix)
-    if len(missing_keys) > 0:
-        print_log(f"[WARNING] Missing keys: {missing_keys}")
-    if len(unexpected_keys) > 0:
-        print_log(f"[WARNING] Unexpected keys: {unexpected_keys}")
-    if error_msgs:
-        raise RuntimeError(
-            "Error(s) in loading state_dict for {}:\n\t{}".format(
-                module_to_load.__class__.__name__, "\n\t".join(error_msgs)
-            )
-        )
+    raise NotImplementedError("DeepSpeed is not supported in this version.")
 
 
 class _ScaleGradient(Function):

--- a/src/models/skywork_unipic_ori.py
+++ b/src/models/skywork_unipic_ori.py
@@ -8,23 +8,9 @@ from transformers.cache_utils import DynamicCache
 from src.builder import BUILDER
 from tqdm import tqdm
 from torch.nn.utils.rnn import pad_sequence
-from transformers.integrations.deepspeed import (
-    is_deepspeed_zero3_enabled,
-    set_hf_deepspeed_config,
-    unset_hf_deepspeed_config, 
-    deepspeed_config
-)
 
-@contextlib.contextmanager
-def temporarily_disable_deepspeed_zero3():
-    if is_deepspeed_zero3_enabled():
-        config = deepspeed_config()
-        print(f'[DEBUG] ds config={config}')
-        unset_hf_deepspeed_config()
-        yield
-        set_hf_deepspeed_config(config)
-    else:
-        yield
+
+
 
 
 
@@ -51,14 +37,13 @@ class SkyworkUnipic(nn.Module):
                  tokenizer,
                  prompt_template):
         super().__init__()
-        with temporarily_disable_deepspeed_zero3():
-            # VAE
-            self.vae = BUILDER.build(vae)
-            self.vae.requires_grad_(False)
-            self.vae_scale = vae_scale
+        # VAE
+        self.vae = BUILDER.build(vae)
+        self.vae.requires_grad_(False)
+        self.vae_scale = vae_scale
 
-            # LLM
-            self.llm = BUILDER.build(llm)
+        # LLM
+        self.llm = BUILDER.build(llm)
         self.tokenizer = BUILDER.build(tokenizer)
         self.prompt_template = prompt_template
 

--- a/zero_to_fp32.py
+++ b/zero_to_fp32.py
@@ -30,10 +30,8 @@ from dataclasses import dataclass
 
 # while this script doesn't use deepspeed to recover data, since the checkpoints are pickled with
 # DeepSpeed data structures it has to be available in the current python environment.
-from deepspeed.utils import logger
-from deepspeed.checkpoint.constants import (DS_VERSION, OPTIMIZER_STATE_DICT, SINGLE_PARTITION_OF_FP32_GROUPS,
-                                            FP32_FLAT_GROUPS, ZERO_STAGE, PARTITION_COUNT, PARAM_SHAPES, BUFFER_NAMES,
-                                            FROZEN_PARAM_SHAPES, FROZEN_PARAM_FRAGMENTS)
+
+raise NotImplementedError("zero_to_fp32.py is not supported without deepspeed. Please use a different method to convert checkpoints.")
 
 
 @dataclass


### PR DESCRIPTION
These changes are needed for running on Windows (vibe-coded with Github Copilot)

Setup commands:
```bash
git clone --branch dev/testrun-on-windows https://github.com/mh-ka/UniPic-win-test.git
cd UniPic\
conda create -n unipic python=3.10.14
conda activate unipic
pip install torch==2.6.0+cu126 torchvision==0.21.0+cu126 --index-url https://download.pytorch.org/whl/cu126
pip install -r requirements.txt
git lfs install
git clone https://huggingface.co/Skywork/Skywork-UniPic-1.5B .\checkpoint
set PYTHONPATH=.;%PYTHONPATH%
```

Before running inference script there is one thing to do manually unfortunately.
-> Edit the file here: _C:\Users\<your-win-username>\miniconda3\envs\unipic\Lib\site-packages\xtuner\utils\handle_moe_load_and_save.py_
```python
import json
import os
import re
from collections import OrderedDict

# instead of 'import deepspeed' use this code
try:
    import deepspeed
except ImportError:
    deepspeed = None
```


Then you can run the test:
```bash
python scripts\image_edit.py configs\models\qwen2_5_1_5b_kl16_mar_h.py --checkpoint checkpoint\pytorch_model.bin --image_size 1024 --image data\sample.png --prompt "Replace the star with a light bulb." --output output.jpg
```